### PR TITLE
Added VTune Amplifier Results to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# VTune Amplifier Results
+**/VTune Amplifier Results


### PR DESCRIPTION
Typical locations look like libs/VersionedStorage-cpp/tests/VTune Amplifier Results/... (depending on the project being profiled).