### PR TITLE
Extract network protocol details

### DIFF
--- a/libs/Matchmaking.Local/src/PeerMatchmakingService.cs
+++ b/libs/Matchmaking.Local/src/PeerMatchmakingService.cs
@@ -421,15 +421,13 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
 
         internal void Stop()
         {
-            var data = new List<(string, Guid)>(localRooms_.Count);
+            (string, Guid)[] data;
             lock (this)
             {
                 timer_.Change(Timeout.Infinite, Timeout.Infinite);
                 timerExpiryTime_ = DateTime.MaxValue;
-                foreach(var r in localRooms_)
-                {
-                    data.Add((r.Category, r.UniqueId));
-                }
+
+                data = localRooms_.Select(r => (r.Category, r.UniqueId)).ToArray();
             }
             proto_.SendServerByeBye(data);
             proto_.Stop();


### PR DESCRIPTION
Motivation - This centralizes the marshalling and makes it easier to write another consumer of the protocol.

Still todo: extract the sends also. This will fully hide the protocol from callers.
The network class can be pushed down from server/client into the proto instance.