### PR TITLE
Add codeowners

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/en/articles/about-code-owners
+
+*   @microsoft/mixed-reality-sharing


### PR DESCRIPTION
Adds the team to PRs by default.

https://help.github.com/articles/about-codeowners/