### PR TITLE
Updated the license template for c++ projects 

### DIFF
--- a/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/Platform.h
+++ b/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/Platform.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <cstdint>

--- a/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/hash.h
+++ b/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/hash.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <cstdint>

--- a/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/windows.h
+++ b/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/windows.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 

--- a/libs/Common-cpp/src/Platform.cpp
+++ b/libs/Common-cpp/src/Platform.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/Common-cpp/src/hash.cpp
+++ b/libs/Common-cpp/src/hash.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 // The content of this file is based on wyhash by Wang Yi, which is released
 // into the public domain: https://github.com/wangyi-fudan/wyhash

--- a/libs/Common-cpp/src/pch.cpp
+++ b/libs/Common-cpp/src/pch.cpp
@@ -1,5 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"

--- a/libs/Common-cpp/src/pch.h
+++ b/libs/Common-cpp/src/pch.h
@@ -1,5 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Behavior.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Behavior.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/enums.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Detail/layout.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Detail/layout.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/enums.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/KeyDescriptor.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/KeyDescriptor.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/enums.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/KeyDescriptorWithHandle.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/KeyDescriptorWithHandle.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/KeyDescriptor.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/KeyIterator.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/KeyIterator.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/KeyView.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/KeyView.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/KeyView.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/Detail/layout.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Snapshot.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Snapshot.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/KeyIterator.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Storage.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Storage.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/Behavior.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/SubkeyIterator.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/SubkeyIterator.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/Detail/layout.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/SubkeyView.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/SubkeyView.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/VersionedPayloadHandle.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Transaction.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/Transaction.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/Behavior.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/VersionedPayloadHandle.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/VersionedPayloadHandle.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/enums.h>

--- a/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/enums.h
+++ b/libs/VersionedStorage-cpp/include/Microsoft/MixedReality/Sharing/VersionedStorage/enums.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <cstdint>

--- a/libs/VersionedStorage-cpp/src/BlockIterator.h
+++ b/libs/VersionedStorage-cpp/src/BlockIterator.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include "src/IndexBlock.h"

--- a/libs/VersionedStorage-cpp/src/HeaderBlock.cpp
+++ b/libs/VersionedStorage-cpp/src/HeaderBlock.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/HeaderBlock.h
+++ b/libs/VersionedStorage-cpp/src/HeaderBlock.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/KeyDescriptor.h>

--- a/libs/VersionedStorage-cpp/src/IndexBlock.h
+++ b/libs/VersionedStorage-cpp/src/IndexBlock.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include "src/layout.h"

--- a/libs/VersionedStorage-cpp/src/KeyDescriptorWithHandle.cpp
+++ b/libs/VersionedStorage-cpp/src/KeyDescriptorWithHandle.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/KeyIterator.cpp
+++ b/libs/VersionedStorage-cpp/src/KeyIterator.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/KeyStateView.h
+++ b/libs/VersionedStorage-cpp/src/KeyStateView.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/enums.h>

--- a/libs/VersionedStorage-cpp/src/KeyVersionBlock.cpp
+++ b/libs/VersionedStorage-cpp/src/KeyVersionBlock.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/KeyVersionBlock.h
+++ b/libs/VersionedStorage-cpp/src/KeyVersionBlock.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include "src/layout.h"

--- a/libs/VersionedStorage-cpp/src/Snapshot.cpp
+++ b/libs/VersionedStorage-cpp/src/Snapshot.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/StateBlock.cpp
+++ b/libs/VersionedStorage-cpp/src/StateBlock.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/StateBlock.h
+++ b/libs/VersionedStorage-cpp/src/StateBlock.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/enums.h>

--- a/libs/VersionedStorage-cpp/src/Storage.cpp
+++ b/libs/VersionedStorage-cpp/src/Storage.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/SubkeyIterator.cpp
+++ b/libs/VersionedStorage-cpp/src/SubkeyIterator.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/SubkeyStateView.h
+++ b/libs/VersionedStorage-cpp/src/SubkeyStateView.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/enums.h>

--- a/libs/VersionedStorage-cpp/src/SubkeyVersionBlock.cpp
+++ b/libs/VersionedStorage-cpp/src/SubkeyVersionBlock.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/SubkeyVersionBlock.h
+++ b/libs/VersionedStorage-cpp/src/SubkeyVersionBlock.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include "src/layout.h"

--- a/libs/VersionedStorage-cpp/src/Transaction.cpp
+++ b/libs/VersionedStorage-cpp/src/Transaction.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"
 

--- a/libs/VersionedStorage-cpp/src/VersionRefCount.h
+++ b/libs/VersionedStorage-cpp/src/VersionRefCount.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include "src/layout.h"

--- a/libs/VersionedStorage-cpp/src/layout.h
+++ b/libs/VersionedStorage-cpp/src/layout.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <Microsoft/MixedReality/Sharing/VersionedStorage/Detail/Layout.h>

--- a/libs/VersionedStorage-cpp/src/pch.cpp
+++ b/libs/VersionedStorage-cpp/src/pch.cpp
@@ -1,5 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "src/pch.h"

--- a/libs/VersionedStorage-cpp/src/pch.h
+++ b/libs/VersionedStorage-cpp/src/pch.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 #include <algorithm>

--- a/libs/VersionedStorage-cpp/tests/HeaderBlock-test.cpp
+++ b/libs/VersionedStorage-cpp/tests/HeaderBlock-test.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "pch.h"
 

--- a/libs/VersionedStorage-cpp/tests/KeyVersionBlock-test.cpp
+++ b/libs/VersionedStorage-cpp/tests/KeyVersionBlock-test.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "pch.h"
 

--- a/libs/VersionedStorage-cpp/tests/StateBlock-test.cpp
+++ b/libs/VersionedStorage-cpp/tests/StateBlock-test.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "pch.h"
 
@@ -86,8 +85,7 @@ TEST(StateBlock, SubkeyStateBlock_payload_and_deletion_marker) {
 
   EXPECT_FALSE(block.GetVersionedPayload(0).has_payload());
   EXPECT_FALSE(block.GetVersionedPayload(99999).has_payload());
-  EXPECT_FALSE(
-      block.GetVersionedPayload(kInvalidVersion - 1).has_payload());
+  EXPECT_FALSE(block.GetVersionedPayload(kInvalidVersion - 1).has_payload());
 
   // Can store any version at first, since it's not compressed.
   EXPECT_TRUE(block.CanPushFromWriterThread(0, true));
@@ -122,8 +120,7 @@ TEST(StateBlock, SubkeyStateBlock_payload_and_deletion_marker) {
   EXPECT_EQ(block.GetVersionedPayload(123'000'400'000ull), v0);
   EXPECT_EQ(block.GetVersionedPayload(123'999'999'999ull), v0);
   EXPECT_FALSE(block.GetVersionedPayload(124'000'000'000ull).has_payload());
-  EXPECT_FALSE(
-      block.GetVersionedPayload(kInvalidVersion - 1).has_payload());
+  EXPECT_FALSE(block.GetVersionedPayload(kInvalidVersion - 1).has_payload());
 
   // The writes above should not overwrite the other properties.
   EXPECT_EQ(block.key_, KeyHandle{42});
@@ -158,8 +155,7 @@ TEST(StateBlock, SubkeyStateBlock_2_payloads_largest_offset) {
 
   EXPECT_FALSE(block.GetVersionedPayload(0).has_payload());
   EXPECT_FALSE(block.GetVersionedPayload(99999).has_payload());
-  EXPECT_FALSE(
-      block.GetVersionedPayload(kInvalidVersion - 1).has_payload());
+  EXPECT_FALSE(block.GetVersionedPayload(kInvalidVersion - 1).has_payload());
 
   // Can store any version at first, since it's not compressed.
   EXPECT_TRUE(block.CanPushFromWriterThread(0, true));
@@ -169,8 +165,7 @@ TEST(StateBlock, SubkeyStateBlock_2_payloads_largest_offset) {
   EXPECT_TRUE(block.CanPushFromWriterThread(223'000'000'000ull, true));
   EXPECT_TRUE(block.CanPushFromWriterThread(223'000'000'000ull, false));
   EXPECT_TRUE(block.CanPushFromWriterThread(kInvalidVersion - 1, true));
-  EXPECT_TRUE(
-      block.CanPushFromWriterThread(kInvalidVersion - 1, false));
+  EXPECT_TRUE(block.CanPushFromWriterThread(kInvalidVersion - 1, false));
 
   block.PushFromWriterThread(123'000'000'000ull, PayloadHandle{123'123'000});
   EXPECT_FALSE(block.GetVersionedPayload(0).has_payload());

--- a/libs/VersionedStorage-cpp/tests/Storage-test.cpp
+++ b/libs/VersionedStorage-cpp/tests/Storage-test.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "pch.h"
 

--- a/libs/VersionedStorage-cpp/tests/SubkeyVersionBlock-test.cpp
+++ b/libs/VersionedStorage-cpp/tests/SubkeyVersionBlock-test.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "pch.h"
 
@@ -46,8 +45,7 @@ class SubkeyVersionBlock_Test : public ::testing::Test {
   // versions in-between.
   bool IsMissingPayloadsBetween(uint64_t first_version,
                                 uint64_t last_version) const noexcept {
-    assert(first_version <= last_version &&
-           last_version < kInvalidVersion);
+    assert(first_version <= last_version && last_version < kInvalidVersion);
     for (uint64_t i = 0; i < 10 && first_version + i < last_version; ++i) {
       if (first_block_.GetVersionedPayload(first_version + i).has_payload())
         return false;
@@ -69,8 +67,7 @@ class SubkeyVersionBlock_Test : public ::testing::Test {
   bool IsPayloadBetween(uint64_t first_version,
                         uint64_t last_version,
                         uint64_t expected_handle_64) const noexcept {
-    assert(first_version <= last_version &&
-           last_version < kInvalidVersion);
+    assert(first_version <= last_version && last_version < kInvalidVersion);
     VersionedPayloadHandle expected_handle{first_version,
                                            PayloadHandle{expected_handle_64}};
 

--- a/libs/VersionedStorage-cpp/tests/TestBehavior.cpp
+++ b/libs/VersionedStorage-cpp/tests/TestBehavior.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "pch.h"
 

--- a/libs/VersionedStorage-cpp/tests/TestBehavior.h
+++ b/libs/VersionedStorage-cpp/tests/TestBehavior.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 

--- a/libs/VersionedStorage-cpp/tests/VersionRefCount-test.cpp
+++ b/libs/VersionedStorage-cpp/tests/VersionRefCount-test.cpp
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "pch.h"
 

--- a/libs/VersionedStorage-cpp/tests/pch.cpp
+++ b/libs/VersionedStorage-cpp/tests/pch.cpp
@@ -1,5 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #include "pch.h"

--- a/libs/VersionedStorage-cpp/tests/pch.h
+++ b/libs/VersionedStorage-cpp/tests/pch.h
@@ -1,6 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license
-// information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 #pragma once
 


### PR DESCRIPTION
Now matches our latest recommendations for open-source.

(The action also reran clang-format for some of the files, but there are no functional changes).