### PR TITLE
Use short MIT boilerplate

### DIFF
--- a/libs/Common.Utilities/src/TaskExtensions.cs
+++ b/libs/Common.Utilities/src/TaskExtensions.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Diagnostics;

--- a/libs/Matchmaking/src/IDiscoveryAgent.cs
+++ b/libs/Matchmaking/src/IDiscoveryAgent.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/libs/Matchmaking/src/IDiscoveryResource.cs
+++ b/libs/Matchmaking/src/IDiscoveryResource.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/libs/Matchmaking/src/Peer/IPeerDiscoveryTransport.cs
+++ b/libs/Matchmaking/src/Peer/IPeerDiscoveryTransport.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/libs/Matchmaking/src/Peer/MemoryPeerDiscoveryTransport.cs
+++ b/libs/Matchmaking/src/Peer/MemoryPeerDiscoveryTransport.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Concurrent;

--- a/libs/Matchmaking/src/Peer/PeerDiscoveryAgent.cs
+++ b/libs/Matchmaking/src/Peer/PeerDiscoveryAgent.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections;

--- a/libs/Matchmaking/src/Peer/UdpPeerDiscoveryTransport.cs
+++ b/libs/Matchmaking/src/Peer/UdpPeerDiscoveryTransport.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Concurrent;

--- a/libs/Matchmaking/src/Util/Log.cs
+++ b/libs/Matchmaking/src/Util/Log.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 #if NETFX_CORE

--- a/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/PeerDiscoveryTest.cs
+++ b/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/PeerDiscoveryTest.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/libs/SpatialAlignment/src/ISpatialCoordinate.cs
+++ b/libs/SpatialAlignment/src/ISpatialCoordinate.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Numerics;

--- a/libs/SpatialAlignment/src/ISpatialCoordinateService.cs
+++ b/libs/SpatialAlignment/src/ISpatialCoordinateService.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/libs/SpatialAlignment/src/SpatialCoordinateBase.cs
+++ b/libs/SpatialAlignment/src/SpatialCoordinateBase.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Numerics;

--- a/libs/SpatialAlignment/src/SpatialCoordinateServiceBase.cs
+++ b/libs/SpatialAlignment/src/SpatialCoordinateServiceBase.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.MixedReality.Sharing.Utilities;
 using System;


### PR DESCRIPTION
Only processed Matchmaking, Common.Utilities, SpatialAlignment to avoid conflicts. #101 