### PR TITLE
Migrating to wyhash v3 #115

### DIFF
--- a/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/Platform.h
+++ b/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/Platform.h
@@ -29,6 +29,15 @@
 #define MS_MR_SHARING_FORCEINLINE __attribute__((always_inline))
 #endif
 
+// This should be eventually replaced with C++20's [[likely]] and [[unlikely]]
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#define MS_MR_LIKELY(EXPRESSION) __builtin_expect(bool(EXPRESSION), 1)
+#define MS_MR_UNLIKELY(EXPRESSION) __builtin_expect(bool(EXPRESSION), 0)
+#else
+#define MS_MR_LIKELY(EXPRESSION) bool(EXPRESSION)
+#define MS_MR_UNLIKELY(EXPRESSION) bool(EXPRESSION)
+#endif
+
 namespace Microsoft::MixedReality::Sharing::Platform {
 
 constexpr uint32_t kPageSize = 4096;

--- a/libs/Common-cpp/src/hash.cpp
+++ b/libs/Common-cpp/src/hash.cpp
@@ -87,8 +87,10 @@ MS_MR_SHARING_FORCEINLINE uint64_t _wyr3(const uint8_t* p, unsigned k) {
 uint64_t CalculateHash64(const char* data,
                          size_t size,
                          uint64_t seed) noexcept {
+  // This is a deviation from the current reference implementation of wyhash
+  // (it would always return 0).
   if (MS_MR_UNLIKELY(!size))
-    return 0;
+    return _wymum(_wymum(seed ^ _wyp0, _wyp1), _wyp2);
 
   uint64_t len = size;
 

--- a/libs/Common-cpp/src/hash.cpp
+++ b/libs/Common-cpp/src/hash.cpp
@@ -114,7 +114,8 @@ uint64_t CalculateHash64(const char* data,
                       _wymum(_wyr8(p + 16) ^ seed ^ _wyp2,
                              _wyr8(p + len - 8) ^ seed ^ _wyp3),
                   len ^ _wyp4);
-  uint64_t see1 = seed, i = len;
+  uint64_t see1 = seed;
+  uint64_t i = len;
   if (i >= 256)
     for (; i >= 256; i -= 256, p += 256) {
       seed = _wymum(_wyr8(p) ^ seed ^ _wyp0, _wyr8(p + 8) ^ seed ^ _wyp1) ^

--- a/libs/Common-cpp/src/hash.cpp
+++ b/libs/Common-cpp/src/hash.cpp
@@ -90,7 +90,7 @@ uint64_t CalculateHash64(const char* data,
   // This is a deviation from the current reference implementation of wyhash
   // (it would always return 0).
   if (MS_MR_UNLIKELY(!size))
-    return _wymum(_wymum(seed ^ _wyp0, _wyp1), _wyp2);
+    return _wymum(_wymum(seed ^ _wyp0, seed ^ _wyp1), _wyp2);
 
   uint64_t len = size;
 

--- a/libs/StateSync.Managed/tests/ManagedTests/KeyTest.cs
+++ b/libs/StateSync.Managed/tests/ManagedTests/KeyTest.cs
@@ -60,16 +60,16 @@ namespace Microsoft.MixedReality.Sharing.StateSync.Test
         public void HashesAreExpected()
         {
             Key keyFoo = new Key("foo");
-            Assert.Equal(0xE7510899, (uint)keyFoo.GetHashCode());
-            Assert.Equal(0x7E9FD358E7510899ul, keyFoo.Hash);
+            Assert.Equal(0xCA796135, (uint)keyFoo.GetHashCode());
+            Assert.Equal(0x836E8217CA796135ul, keyFoo.Hash);
 
             Key keyBar = new Key("bar");
-            Assert.Equal(0x14C86F89, keyBar.GetHashCode());
-            Assert.Equal(0x8BBDFB3714C86F89, keyBar.Hash);
+            Assert.Equal(0x562585D9, keyBar.GetHashCode());
+            Assert.Equal(0x6E84777F562585D9ul, keyBar.Hash);
 
             Key keyWithZeros = new Key(bytesWithZeros);
-            Assert.Equal(0x791286E1, keyWithZeros.GetHashCode());
-            Assert.Equal(0x647D1028791286E1ul, keyWithZeros.Hash);
+            Assert.Equal(0x6B4EE12F, keyWithZeros.GetHashCode());
+            Assert.Equal(0x8F5FBB1D6B4EE12Ful, keyWithZeros.Hash);
         }
     }
 }


### PR DESCRIPTION
Migrating to wyhash v3, specifically to WYHASH32 version of it to have consistent perf. between Hololens 1 and 64-bit platforms.

The code is mostly copy-pasted from the current version of https://github.com/wangyi-fudan/wyhash/blob/master/wyhash.h, which is licensed under Unlicense (public domain). The changes from the original include:
- applying clang-format (to avoid special-casing this file) and splitting lines that declare multiple variables into individual lines.
- Adding noexcept/constexpr/MS_MR_SHARING_FORCEINLINE in a few places.
- Eliminating warnings related to implicit narrowing casts (by introducing static_cast there).
- Extracting MS_MR_LIKELY/MS_MR_UNLIKELY (it will be useful in a few other places).
- Making sure that size arg stays size_t (it's uint64_t in the original source).
- Removing parts related to the random number generator (unused; plus it would be thread-unsafe anyway).

The output of the hash is different from previously used v2, but should be identical to the reference implementation of v3 with WYHASH32 define.

Bug: #115 
