### PR TITLE
Reducing the amount of warnings in Debug/x86 build.

### DIFF
--- a/libs/Common-cpp/Microsoft.MixedReality.Sharing.Common-cpp.vcxproj
+++ b/libs/Common-cpp/Microsoft.MixedReality.Sharing.Common-cpp.vcxproj
@@ -128,6 +128,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>src/pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -144,6 +145,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>src/pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/libs/StateSync-cpp/Microsoft.MixedReality.Sharing.StateSync-cpp.vcxproj
+++ b/libs/StateSync-cpp/Microsoft.MixedReality.Sharing.StateSync-cpp.vcxproj
@@ -119,6 +119,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>src/pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -135,6 +136,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>src/pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/libs/StateSync-pinvoke-cpp/Microsoft.MixedReality.Sharing.StateSync-pinvoke-cpp.vcxproj
+++ b/libs/StateSync-pinvoke-cpp/Microsoft.MixedReality.Sharing.StateSync-pinvoke-cpp.vcxproj
@@ -122,6 +122,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>src/pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -138,6 +139,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>src/pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/libs/StateSync-pinvoke-cpp/src/Key-pinvoke.cpp
+++ b/libs/StateSync-pinvoke-cpp/src/Key-pinvoke.cpp
@@ -32,7 +32,7 @@ Microsoft_MixedReality_Sharing_StateSync_Key_view(intptr_t handle,
   if (auto* key = bit_cast<const Key*>(handle)) {
     auto view = key->view();
     // TODO: ensure that we never allow keys larger than INT_MAX
-    assert(view.size() < std::numeric_limits<int>::max());
+    assert(view.size() < static_cast<size_t>(std::numeric_limits<int>::max()));
     *out_size = static_cast<int>(view.size());
     return view.data();
   }

--- a/libs/StateSync-pinvoke-cpp/src/Value-pinvoke.cpp
+++ b/libs/StateSync-pinvoke-cpp/src/Value-pinvoke.cpp
@@ -39,7 +39,7 @@ Microsoft_MixedReality_Sharing_StateSync_Value_view(intptr_t handle,
   if (auto* value = bit_cast<const Value*>(handle)) {
     auto view = value->view();
     // TODO: ensure that we never allow values larger than INT_MAX
-    assert(view.size() < std::numeric_limits<int>::max());
+    assert(view.size() < static_cast<size_t>(std::numeric_limits<int>::max()));
     *out_size = static_cast<int>(view.size());
     return view.data();
   }

--- a/libs/VersionedStorage-cpp/Microsoft.MixedReality.Sharing.VersionedStorage-cpp.vcxproj
+++ b/libs/VersionedStorage-cpp/Microsoft.MixedReality.Sharing.VersionedStorage-cpp.vcxproj
@@ -149,6 +149,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>src/pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -165,6 +166,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>src/pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
/ZI+/SAFESEH incompatibility (swiched to /Zi) and signed/unsigned warning (in placeholder code, but might as well clean it up in advance).