### PR TITLE
Remove unneeded MRS_DevOptOut variable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Common properties -->
-  <PropertyGroup Condition=" '$(MRS_DevOptOut)' == '' OR '$(MRS_DevOptOut)' == 'false' ">
+  <PropertyGroup>
     <!-- SolutionDir is not defined when building projects explicitly -->
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Microsoft.MixedReality.Sharing.sln))\</SolutionDir>
 

--- a/libs/SpatialAlignment-Unity/Directory.Build.props
+++ b/libs/SpatialAlignment-Unity/Directory.Build.props
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!-- This file only exists to prevent the Build.props from the project root being imported -->
 </Project>

--- a/libs/SpatialAlignment-Unity/Directory.Build.props
+++ b/libs/SpatialAlignment-Unity/Directory.Build.props
@@ -1,6 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <MRS_DevOptOut>true</MRS_DevOptOut>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
@andreiborodin this article implies that the search for build props stops as soon as one is found.
https://thomaslevesque.com/2017/09/18/common-msbuild-properties-and-items-with-directory-build-props/

So, we should be able to simply remove the MRS_DevOptOut variable?