### PR TITLE
Make multithreading more consistent

### DIFF
--- a/libs/Matchmaking/src/IDiscoveryAgent.cs
+++ b/libs/Matchmaking/src/IDiscoveryAgent.cs
@@ -16,8 +16,8 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
     /// (including `Dispose()`) must be safe to use independently from the state of the agent - even from a
     /// different thread from the one where the agent is used.
     ///
-    /// After the agent is disposed, the result of <see cref="Resources"/> becomes undefined, and
-    /// <see cref="Updated"/> might stop being raised.
+    /// After the agent is disposed, the result of <see cref="Resources"/> eventually becomes empty, and
+    /// <see cref="Updated"/> stops being raised.
     /// </remarks>
     public interface IDiscoverySubscription : IDisposable
     {

--- a/libs/Matchmaking/src/IDiscoveryAgent.cs
+++ b/libs/Matchmaking/src/IDiscoveryAgent.cs
@@ -16,7 +16,8 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
     /// (including `Dispose()`) must be safe to use independently from the state of the agent - even from a
     /// different thread from the one where the agent is used.
     ///
-    /// After the agent is disposed, the might stop returning meaningful resources and/or raising <see cref="Updated"/>.
+    /// After the agent is disposed, the result of <see cref="Resources"/> becomes undefined, and
+    /// <see cref="Updated"/> might stop being raised.
     /// </remarks>
     public interface IDiscoverySubscription : IDisposable
     {

--- a/libs/Matchmaking/src/IDiscoveryAgent.cs
+++ b/libs/Matchmaking/src/IDiscoveryAgent.cs
@@ -11,6 +11,13 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
     /// <summary>
     /// Handle to an ongoing discovery subscription.
     /// </summary>
+    /// <remarks>
+    /// A subscription is bound to the originating <see cref="IDiscoveryAgent"/>, but its methods/properties
+    /// (including `Dispose()`) must be safe to use independently from the state of the agent - even from a
+    /// different thread from the one where the agent is used.
+    ///
+    /// After the agent is disposed, the might stop returning meaningful resources and/or raising <see cref="Updated"/>.
+    /// </remarks>
     public interface IDiscoverySubscription : IDisposable
     {
         /// <summary>

--- a/libs/Matchmaking/src/Peer/IPeerDiscoveryTransport.cs
+++ b/libs/Matchmaking/src/Peer/IPeerDiscoveryTransport.cs
@@ -48,6 +48,9 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
         /// <summary>
         /// Send a message to all others in this transport.
         /// </summary>
+        /// <remarks>
+        /// Must be thread-safe with respect to other calls to the same method and <see cref="Reply(IPeerDiscoveryMessage, Guid, ArraySegment{byte})"/>.
+        /// </remarks>
         /// <param name="streamId">
         /// Associates the message to a stream. Messages from the same stream will be delivered in order.
         /// No guarantees are made on messages from different stream. <see cref="System.Guid.Empty"/> can be used
@@ -57,8 +60,11 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
         void Broadcast(Guid streamId, ArraySegment<byte> message);
 
         /// <summary>
-        /// Reply to a message. (Typically a broadcast message)
+        /// Reply to a message (typically a broadcast message). Must be thread-safe.
         /// </summary>
+        /// <remarks>
+        /// Must be thread-safe with respect to other calls to the same method and <see cref="Broadcast(Guid, ArraySegment{byte})"/>.
+        /// </remarks>
         /// <param name="streamId">
         /// Associates the message to a stream. Messages from the same stream will be delivered in order.
         /// No guarantees are made on messages from different stream. <see cref="System.Guid.Empty"/> can be used

--- a/libs/Matchmaking/src/Peer/PeerDiscoveryAgent.cs
+++ b/libs/Matchmaking/src/Peer/PeerDiscoveryAgent.cs
@@ -620,7 +620,10 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
                     }
                     tasksUpdated.Clear();
                 }
-            }, token);
+            }, token).ContinueWith(_ =>
+            {
+                updateCts_.Dispose();
+            });
         }
 
         internal IDisposedEventDiscoveryTask StartDiscovery(string category)
@@ -648,7 +651,6 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
             // Do not wait for the end of the update thread since it runs external handlers,
             // and we might be stuck for a long time/deadlock.
             updateCts_.Cancel();
-            updateCts_.Dispose();
 
             proto_.Stop();
 

--- a/libs/Matchmaking/src/Peer/PeerDiscoveryAgent.cs
+++ b/libs/Matchmaking/src/Peer/PeerDiscoveryAgent.cs
@@ -607,9 +607,16 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
                     }
 
                     // Outside the lock.
-                    foreach (var t in tasksUpdated)
+                    try
                     {
-                        t.FireUpdated();
+                        foreach (var t in tasksUpdated)
+                        {
+                            t.FireUpdated();
+                        }
+                    }
+                    catch(Exception e)
+                    {
+                        Log.Error(e, "Error while firing update");
                     }
                     tasksUpdated.Clear();
                 }

--- a/libs/Matchmaking/src/Peer/PeerDiscoveryAgent.cs
+++ b/libs/Matchmaking/src/Peer/PeerDiscoveryAgent.cs
@@ -791,9 +791,9 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking
             }
         }
 
-        // Note: must be called under lock.
         private void SetExpirationTimer(DateTime expiryTime)
         {
+            Debug.Assert(Monitor.IsEntered(this)); // Caller should have lock(this)
             // Use int since UWP does not implement long ctor.
             int deltaMsInt;
             if (expiryTime == DateTime.MaxValue)

--- a/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/PeerDiscoveryTest.cs
+++ b/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/PeerDiscoveryTest.cs
@@ -313,7 +313,13 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
                 // Signal the handler to go ahead and dispose the subscription.
                 agentDisposed.Set();
 
-                // Dispose the other surviving task.
+                // The resources in the other surviving subscription are cleared eventually.
+                while(surviving.Resources.Any())
+                {
+                    Task.Delay(1).Wait(cts.Token);
+                }
+
+                // Dispose the other surviving subscription.
                 surviving.Dispose();
 
                 WaitWithCancellation(survivingDisposedEvent, cts.Token);

--- a/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/Utils.cs
+++ b/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/Utils.cs
@@ -5,6 +5,8 @@ using Microsoft.MixedReality.Sharing.Matchmaking;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Xunit;
 
@@ -16,7 +18,7 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
         {
             get
             {
-                return Debugger.IsAttached ? Timeout.Infinite : 10000;
+                return /*Debugger.IsAttached ? Timeout.Infinite :*/ 10000;
             }
         }
 
@@ -91,6 +93,48 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
                             return null;
                         }
                     }
+                }
+            }
+        }
+
+        // Utility that captures any exception thrown by a block of code to throw it later.
+        public class DelayedException
+        {
+            private Exception exception_;
+            public void Run(Action action)
+            {
+                try
+                {
+                    action();
+                }
+                catch(Exception e)
+                {
+                    exception_ = e;
+                }
+            }
+
+            public Action Wrap(Action action)
+            {
+                return () => { action(); };
+            }
+
+            public Action<T1> Wrap<T1>(Action<T1> action)
+            {
+                return (t1) => { action(t1); };
+            }
+
+            public Action<T1, T2> Wrap<T1, T2>(Action<T1, T2> action)
+            {
+                return (t1, t2) => { action(t1, t2); };
+            }
+
+            // Add more if necessary
+
+            public void Rethrow()
+            {
+                if (exception_ != null)
+                {
+                    ExceptionDispatchInfo.Capture(exception_).Throw();
                 }
             }
         }

--- a/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/Utils.cs
+++ b/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/Utils.cs
@@ -115,17 +115,39 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
 
             public Action Wrap(Action action)
             {
-                return () => { action(); };
+                return () => { Run(action); };
+            }
+            public void Run<T1>(Action<T1> action, T1 t1)
+            {
+                try
+                {
+                    action(t1);
+                }
+                catch (Exception e)
+                {
+                    exception_ = e;
+                }
             }
 
             public Action<T1> Wrap<T1>(Action<T1> action)
             {
-                return (t1) => { action(t1); };
+                return (t1) => { Run(action, t1); };
+            }
+            public void Run<T1, T2>(Action<T1, T2> action, T1 t1, T2 t2)
+            {
+                try
+                {
+                    action(t1, t2);
+                }
+                catch (Exception e)
+                {
+                    exception_ = e;
+                }
             }
 
             public Action<T1, T2> Wrap<T1, T2>(Action<T1, T2> action)
             {
-                return (t1, t2) => { action(t1, t2); };
+                return (t1, t2) => { Run(action, t1, t2); };
             }
 
             // Add more if necessary

--- a/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/Utils.cs
+++ b/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/Utils.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
         {
             get
             {
-                return /*Debugger.IsAttached ? Timeout.Infinite :*/ 10000;
+                return Debugger.IsAttached ? Timeout.Infinite : 10000;
             }
         }
 


### PR DESCRIPTION
Fixes #97. Fixes #98.

The new behavior follows the simple principles (reasonable IMHO) that:
- calling methods on the same object from different threads must not necessarily be safe (unless specified)
- calling methods on different objects (e.g. an agent and one of its subscription) from different threads should be safe.