### PR TITLE
Enable different broadcast domains for MemoryPeerDiscoveryTransport

### DIFF
--- a/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/ITransportBuilder.cs
+++ b/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/ITransportBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -19,9 +20,11 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
 
     internal class MemoryTransportBuilder : ITransportBuilder
     {
+        private readonly ushort port_ = Utils.NewPortNumber.Calculate();
+
         public IPeerDiscoveryTransport MakeTransport(int userIndex)
         {
-            return new MemoryPeerDiscoveryTransport(userIndex);
+            return new MemoryPeerDiscoveryTransport(port_);
         }
 
         public bool SimulatesPacketLoss => false;

--- a/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/SimpleTest.cs
+++ b/libs/Matchmaking/test/Matchmaking.PeerDiscovery.Test/SimpleTest.cs
@@ -62,10 +62,10 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
         [Fact]
         public void ResourceExpiresOnTime()
         {
-            var random = new Random();
             const int timeoutSec = 1;
-            var network1 = new MemoryPeerDiscoveryTransport(random.Next());
-            var network2 = new MemoryPeerDiscoveryTransport(random.Next());
+            int port = Utils.NewPortNumber.Calculate();
+            var network1 = new MemoryPeerDiscoveryTransport(port);
+            var network2 = new MemoryPeerDiscoveryTransport(port);
             using (var cts = new CancellationTokenSource(Utils.TestTimeoutMs))
             using (var svc1 = new PeerDiscoveryAgent(network1))
             {
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
                         Assert.Equal(resource1.UniqueId, res1.First().UniqueId);
                     }
 
-                    // Stop the network.
+                    // Stop the transport.
                     network1.Stop();
                     {
                         // The resource eventually expires.
@@ -94,7 +94,7 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
                         Assert.Empty(res1);
                     }
 
-                    // Restart the network.
+                    // Restart the transport.
                     network1.Start();
                     {
                         // The resource appears again.
@@ -103,13 +103,16 @@ namespace Microsoft.MixedReality.Sharing.Matchmaking.Test
                         Assert.Equal(resource1.UniqueId, res1.First().UniqueId);
                     }
 
-                    // Stop the network.
+                    // Stop the transport.
                     network1.Stop();
                     {
                         // The resource expires again.
                         var res1 = Utils.QueryAndWaitForResourcesPredicate(svc1, category, rl => rl.Count() == 0, cts.Token);
                         Assert.Empty(res1);
                     }
+
+                    // Restart the transport so that the agent disposal can stop it without exceptions.
+                    network1.Start();
                 }
             }
         }


### PR DESCRIPTION
Prevents interference between tests when run at the same time