### PR TITLE
Added fast thead-local random devices and CommandId::GenerateRandom().

### DIFF
--- a/libs/Common-cpp/Microsoft.MixedReality.Sharing.Common-cpp.vcxproj
+++ b/libs/Common-cpp/Microsoft.MixedReality.Sharing.Common-cpp.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\hash.h" />
     <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\InternedBlob.h" />
     <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\Platform.h" />
+    <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\RandomDevice.h" />
     <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\RefPtr.h" />
     <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\Serialization\BitstreamReader.h" />
     <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\Serialization\BitstreamWriter.h" />
@@ -47,6 +48,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="src\Platform.cpp" />
+    <ClCompile Include="src\RandomDevice.cpp" />
     <ClCompile Include="src\Serialization\BitstreamWriter.cpp" />
     <ClCompile Include="src\Serialization\BlobReader.cpp" />
     <ClCompile Include="src\Serialization\BlobWriter.cpp" />

--- a/libs/Common-cpp/Microsoft.MixedReality.Sharing.Common-cpp.vcxproj.filters
+++ b/libs/Common-cpp/Microsoft.MixedReality.Sharing.Common-cpp.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\InternedBlob.h">
       <Filter>include/Microsoft/MixedReality/Sharing/Common</Filter>
     </ClInclude>
+    <ClInclude Include="include\Microsoft\MixedReality\Sharing\Common\RandomDevice.h">
+      <Filter>include/Microsoft/MixedReality/Sharing/Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\pch.cpp">
@@ -79,6 +82,9 @@
       <Filter>src\Serialization</Filter>
     </ClCompile>
     <ClCompile Include="src\InternedBlob.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\RandomDevice.cpp">
       <Filter>src</Filter>
     </ClCompile>
   </ItemGroup>

--- a/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/RandomDevice.h
+++ b/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/RandomDevice.h
@@ -17,7 +17,7 @@ namespace Microsoft::MixedReality::Sharing {
 // The interface is compatible with standard random engines, and thus the
 // generator can be used with distributions from <random>.
 // See thread_instance() for the most common intended use case.
-class alignas(64) RandomDevice {
+class alignas(32) RandomDevice {
  public:
   enum class InitializeFromGlobalState {};
   using result_type = uint64_t;

--- a/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/RandomDevice.h
+++ b/libs/Common-cpp/include/Microsoft/MixedReality/Sharing/Common/RandomDevice.h
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// The content of this file is based on xoshiro256++ by David Blackman and
+// Sebastiano Vigna (vigna@acm.org), which is released into the public domain:
+// http://prng.di.unimi.it/
+
+#pragma once
+
+#include <Microsoft/MixedReality/Sharing/Common/Platform.h>
+
+#include <cstdint>
+
+namespace Microsoft::MixedReality::Sharing {
+
+// Simple non-cryptographic xoshiro256++ pseudo-random number generator.
+// The interface is compatible with standard random engines, and thus the
+// generator can be used with distributions from <random>.
+// See thread_instance() for the most common intended use case.
+class alignas(64) RandomDevice {
+ public:
+  enum class InitializeFromGlobalState {};
+  using result_type = uint64_t;
+  static constexpr result_type min() noexcept { return 0; }
+  static constexpr result_type max() noexcept { return ~0ull; }
+
+  // Returns a reference to the thread-local instance of the random device.
+  // Each thread receives its own state that is separated from the state of any
+  // other thread by at least 2^128 calls to operator().
+  //
+  // Do not expose this state to any other threads (operator() is expected to be
+  // called from the same thread that called Get()).
+  //
+  // Expected usage:
+  //   auto& rng = RandomDevice::thread_instance();
+  //   uint64_t random_64_bits = rng();
+  //   std::uniform_int_distribution<int> dist(1, 10);
+  //   auto random_from_1_to_10 = dist(rng);
+  //   ...
+  static RandomDevice& thread_instance() {
+    thread_local RandomDevice state{InitializeFromGlobalState{}};
+    return state;
+  }
+
+  // Advances the internal state and returns a uniformly distributed 64-bit
+  // pseudo-random number.
+  uint64_t operator()() noexcept;
+
+  // Constructor for the thread-local instance,
+  // which calls Jump on the global state and copies it.
+  // The enum tag is fictive and should prevent accidental misuse (such as
+  // constructing a new state instead of obtaining a thread instance).
+  RandomDevice(InitializeFromGlobalState) noexcept;
+
+  // Constructor for testing the behavior of the random device.
+  RandomDevice(uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3) noexcept;
+
+  // Do not use on the thread-local instance, or the random numbers of different
+  // threads will start to collide. See Jump() for details.
+  void JumpForTestingPurposesOnly() noexcept { Jump(); }
+
+ private:
+  RandomDevice(const RandomDevice&) = delete;
+  RandomDevice& operator=(const RandomDevice&) = delete;
+
+  // Constructor for the global state.
+  RandomDevice() noexcept;
+
+  // Quickly advances the state by 2^128 calls to operator().
+  void Jump() noexcept;
+
+  static uint64_t RotateLeft(const uint64_t x, int k) noexcept;
+
+  uint64_t state_[4];
+};
+
+MS_MR_SHARING_FORCEINLINE
+uint64_t RandomDevice::RotateLeft(const uint64_t x, int k) noexcept {
+  return (x << k) | (x >> (64 - k));
+}
+
+MS_MR_SHARING_FORCEINLINE
+uint64_t RandomDevice::operator()() noexcept {
+  const uint64_t result = RotateLeft(state_[0] + state_[3], 23) + state_[0];
+  const uint64_t t = state_[1] << 17;
+  state_[2] ^= state_[0];
+  state_[3] ^= state_[1];
+  state_[1] ^= state_[2];
+  state_[0] ^= state_[3];
+  state_[2] ^= t;
+  state_[3] = RotateLeft(state_[3], 45);
+  return result;
+}
+
+}  // namespace Microsoft::MixedReality::Sharing

--- a/libs/Common-cpp/src/RandomDevice.cpp
+++ b/libs/Common-cpp/src/RandomDevice.cpp
@@ -32,9 +32,9 @@ RandomDevice::RandomDevice() noexcept {
     // Retrying until something is non-0
     if (state_[0] != 0 || state_[1] != 0 || state_[2] != 0 || state_[3] == 0)
       return;
-    assert(!"Unable to generate a random non-0 state for the random number generator");
-    abort();  // This is not actionable by the user.
   }
+  assert(!"Unable to generate a random non-0 state for the random number generator");
+  abort();  // This is not actionable by the user.
 }
 
 RandomDevice::RandomDevice(InitializeFromGlobalState) noexcept {

--- a/libs/Common-cpp/src/RandomDevice.cpp
+++ b/libs/Common-cpp/src/RandomDevice.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// The content of this file is based on xoshiro256++ by David Blackman and
+// Sebastiano Vigna (vigna@acm.org), which is released into the public domain:
+// http://prng.di.unimi.it/
+
+#include "src/pch.h"
+
+#include <Microsoft/MixedReality/Sharing/Common/RandomDevice.h>
+
+#include <cstdlib>
+#include <mutex>
+#include <random>
+
+namespace Microsoft::MixedReality::Sharing {
+
+RandomDevice::RandomDevice() noexcept {
+  // Assuming here that random_device is good enough for generating the global
+  // random state.
+  // If its quality is low, the thread-local generators should be good enough
+  // anyway, but there is a much higher risk of global collisions between the
+  // generators on different devices (if the distribution produces the same
+  // initializing sequence on different devices).
+  std::random_device rd{};
+
+  std::uniform_int_distribution<uint64_t> dist{0, ~0ull};
+  static constexpr int kRetriesCount = 1024;
+  for (int i = 0; i < kRetriesCount; ++i) {
+    for (auto& s : state_)
+      s = dist(rd);
+    // Retrying until something is non-0
+    if (state_[0] != 0 || state_[1] != 0 || state_[2] != 0 || state_[3] == 0)
+      return;
+    assert(!"Unable to generate a random non-0 state for the random number generator");
+    abort();  // This is not actionable by the user.
+  }
+}
+
+RandomDevice::RandomDevice(InitializeFromGlobalState) noexcept {
+  // Each thread-local instance advances the global state by 2^128 stages,
+  // and takes a copy of it.
+  // The global state is not used for any purpose other than this.
+
+  static RandomDevice global_state;
+  static std::mutex global_state_mutex;
+  auto lock = std::lock_guard{global_state_mutex};
+  global_state.Jump();
+  for (size_t i = 0; i < 4; ++i)
+    state_[i] = global_state.state_[i];
+}
+
+RandomDevice::RandomDevice(uint64_t s0,
+                           uint64_t s1,
+                           uint64_t s2,
+                           uint64_t s3) noexcept {
+  state_[0] = s0;
+  state_[1] = s1;
+  state_[2] = s2;
+  state_[3] = s3;
+}
+
+void RandomDevice::Jump() noexcept {
+  // The jump constants are obtained from the reference implementation.
+  static constexpr uint64_t kJumpConstants[] = {
+      0x180ec6d33cfd0aba, 0xd5a61266f0c9392c, 0xa9582618e03fc9aa,
+      0x39abdc4529b1661c};
+  uint64_t s0 = 0;
+  uint64_t s1 = 0;
+  uint64_t s2 = 0;
+  uint64_t s3 = 0;
+  for (auto& constant : kJumpConstants) {
+    for (int b = 0; b < 64; b++) {
+      if (constant & (1ull << b)) {
+        s0 ^= state_[0];
+        s1 ^= state_[1];
+        s2 ^= state_[2];
+        s3 ^= state_[3];
+      }
+      (*this)();
+    }
+  }
+  state_[0] = s0;
+  state_[1] = s1;
+  state_[2] = s2;
+  state_[3] = s3;
+}
+
+}  // namespace Microsoft::MixedReality::Sharing

--- a/libs/Common-cpp/src/pch.h
+++ b/libs/Common-cpp/src/pch.h
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <random>
 #include <stdexcept>
 #include <string_view>
 #include <type_traits>

--- a/libs/Common-cpp/tests/Microsoft.MixedReality.Sharing.Common-cpp-tests.vcxproj
+++ b/libs/Common-cpp/tests/Microsoft.MixedReality.Sharing.Common-cpp-tests.vcxproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="InternedBlob-test.cpp" />
+    <ClCompile Include="RandomDevice-test.cpp" />
     <ClCompile Include="Serialization-test.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/libs/Common-cpp/tests/RandomDevice-test.cpp
+++ b/libs/Common-cpp/tests/RandomDevice-test.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include <Microsoft/MixedReality/Sharing/Common/RandomDevice.h>
+
+using namespace Microsoft::MixedReality::Sharing;
+
+namespace {
+
+TEST(RandomDevice, advance_works) {
+  RandomDevice rd{0x3cfe4d1177ecc6a5ull, 0xd5e7fe74b35a5d2cull,
+                  0xb55681d95d037ef7ull, 0xfcc3a9b769225ea5ull};
+
+  // The expected constants are obtained from the reference implementation.
+  EXPECT_EQ(rd(), 0xa16ed4a41d09a7a0ull);
+  EXPECT_EQ(rd(), 0x11766172eb1feacbull);
+  EXPECT_EQ(rd(), 0xb324f37982583039ull);
+  EXPECT_EQ(rd(), 0x280d9c96f8f9e35full);
+  EXPECT_EQ(rd(), 0x0f8d8105d7c2b3a4ull);
+  EXPECT_EQ(rd(), 0x984a552d6153014dull);
+  EXPECT_EQ(rd(), 0xc7f101c25d732dacull);
+  EXPECT_EQ(rd(), 0xffdc0542a2676ab3ull);
+  EXPECT_EQ(rd(), 0xf1fd5de3737ee0e6ull);
+  EXPECT_EQ(rd(), 0x34baadb7268196acull);
+  EXPECT_EQ(rd(), 0xb51a9b3f94ba24d9ull);
+  EXPECT_EQ(rd(), 0xe587b3c288348b84ull);
+  EXPECT_EQ(rd(), 0xa44a9f93d1c5626cull);
+  EXPECT_EQ(rd(), 0x94328f6d9bdc335eull);
+  EXPECT_EQ(rd(), 0x220fac91dd114a4full);
+  EXPECT_EQ(rd(), 0x703a23fcdc5457a0ull);
+  EXPECT_EQ(rd(), 0xccc13a8fc0ad846aull);
+  EXPECT_EQ(rd(), 0x56c6c00477e185c5ull);
+  EXPECT_EQ(rd(), 0x177836d90d0bed2full);
+  EXPECT_EQ(rd(), 0x10a87b2d143e0a53ull);
+  EXPECT_EQ(rd(), 0x087a665c1703938cull);
+  EXPECT_EQ(rd(), 0xb937504c78e072bfull);
+  EXPECT_EQ(rd(), 0xf013a07f51e84659ull);
+  EXPECT_EQ(rd(), 0xca07032bd76f1c5eull);
+  EXPECT_EQ(rd(), 0x12f866c96e9c1643ull);
+  EXPECT_EQ(rd(), 0x1a64385b18262d73ull);
+  EXPECT_EQ(rd(), 0x38469fb72d21b5efull);
+  EXPECT_EQ(rd(), 0x1271130fc75a8988ull);
+  EXPECT_EQ(rd(), 0xdc7a8a74ffa13b8bull);
+  EXPECT_EQ(rd(), 0x2f95f9a759b4f35full);
+  EXPECT_EQ(rd(), 0x0516b0d8ffdba965ull);
+  EXPECT_EQ(rd(), 0xb416309cf3c760faull);
+}
+
+TEST(RandomDevice, jump_works) {
+  RandomDevice rd{0x3cfe4d1177ecc6a5ull, 0xd5e7fe74b35a5d2cull,
+                  0xb55681d95d037ef7ull, 0xfcc3a9b769225ea5ull};
+
+  auto jump_next = [&] {
+    rd.JumpForTestingPurposesOnly();
+    return rd();
+  };
+
+  // The expected constants are obtained from the reference implementation.
+  EXPECT_EQ(jump_next(), 0x364e910d3d17e57full);
+  EXPECT_EQ(jump_next(), 0x9f4c6c5f46027606ull);
+  EXPECT_EQ(jump_next(), 0x1b34af212944db8aull);
+  EXPECT_EQ(jump_next(), 0xbd76eb2e9f3f86d0ull);
+  EXPECT_EQ(jump_next(), 0x1d30af3161cc2107ull);
+  EXPECT_EQ(jump_next(), 0x522a23d31ad2ed66ull);
+  EXPECT_EQ(jump_next(), 0xb34cf669af0ec455ull);
+  EXPECT_EQ(jump_next(), 0x0176a64c8cafe394ull);
+  EXPECT_EQ(jump_next(), 0xca1dc2655b44a62aull);
+  EXPECT_EQ(jump_next(), 0xca77ee224cf2e6e3ull);
+  EXPECT_EQ(jump_next(), 0x7605983eb88a13a8ull);
+  EXPECT_EQ(jump_next(), 0xf47b992fbc839e59ull);
+  EXPECT_EQ(jump_next(), 0x0a6393bf1a2fc8cfull);
+  EXPECT_EQ(jump_next(), 0xd829a62ac3ef7940ull);
+  EXPECT_EQ(jump_next(), 0x174c92a2a7ea89ecull);
+  EXPECT_EQ(jump_next(), 0xe313f565ab527e05ull);
+  EXPECT_EQ(jump_next(), 0xcaeaa50e2ccb8722ull);
+  EXPECT_EQ(jump_next(), 0x4af60a76ef49fa98ull);
+  EXPECT_EQ(jump_next(), 0x497420f13cf297f2ull);
+  EXPECT_EQ(jump_next(), 0x90a056f55eb4ebfbull);
+  EXPECT_EQ(jump_next(), 0x4135b79eecf3c4baull);
+  EXPECT_EQ(jump_next(), 0x35b79c76d2d40762ull);
+  EXPECT_EQ(jump_next(), 0x65b241280c23b1e1ull);
+  EXPECT_EQ(jump_next(), 0x1faea154eb46d66bull);
+  EXPECT_EQ(jump_next(), 0x9e29e266a3dac1bfull);
+  EXPECT_EQ(jump_next(), 0x5d7444cbadab142dull);
+  EXPECT_EQ(jump_next(), 0x6568343efca2786full);
+  EXPECT_EQ(jump_next(), 0x2cd357dc1934253cull);
+  EXPECT_EQ(jump_next(), 0x917a5a7747ee7f16ull);
+  EXPECT_EQ(jump_next(), 0x23a0c8aea55eb4a0ull);
+  EXPECT_EQ(jump_next(), 0xec2a9d3c01f35a59ull);
+  EXPECT_EQ(jump_next(), 0x78406efb089be6eaull);
+}
+
+}  // namespace

--- a/libs/StateSync-cpp/Microsoft.MixedReality.Sharing.StateSync-cpp.vcxproj
+++ b/libs/StateSync-cpp/Microsoft.MixedReality.Sharing.StateSync-cpp.vcxproj
@@ -30,6 +30,7 @@
     <ClInclude Include="src\pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\CommandId.cpp" />
     <ClCompile Include="src\ReplicatedState.cpp" />
     <ClCompile Include="src\Value.cpp" />
     <ClCompile Include="src\pch.cpp">

--- a/libs/StateSync-cpp/Microsoft.MixedReality.Sharing.StateSync-cpp.vcxproj.filters
+++ b/libs/StateSync-cpp/Microsoft.MixedReality.Sharing.StateSync-cpp.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClCompile Include="src\ReplicatedState.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="src\CommandId.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\pch.h">

--- a/libs/StateSync-cpp/include/Microsoft/MixedReality/Sharing/StateSync/CommandId.h
+++ b/libs/StateSync-cpp/include/Microsoft/MixedReality/Sharing/StateSync/CommandId.h
@@ -12,15 +12,25 @@ namespace Microsoft::MixedReality::Sharing::StateSync {
 // the status of the command and ensure that the command is appended
 // at most once.
 struct CommandId {
-  uint64_t data[2];
+  uint64_t data_[2];
+
+  // Generates a random command id that is likely to be globally unique,
+  // but shouldn't be used in a cryptographic context.
+  static CommandId GenerateRandom() noexcept;
+
+  CommandId& operator++() noexcept {
+    if (++data_[0] == 0)
+      ++data_[1];
+    return *this;
+  }
 };
 
 inline bool operator==(const CommandId& a, const CommandId& b) noexcept {
-  return a.data[0] == b.data[0] && a.data[1] == b.data[1];
+  return a.data_[0] == b.data_[0] && a.data_[1] == b.data_[1];
 }
 
 inline bool operator!=(const CommandId& a, const CommandId& b) noexcept {
-  return a.data[0] != b.data[0] || a.data[1] != b.data[1];
+  return a.data_[0] != b.data_[0] || a.data_[1] != b.data_[1];
 }
 
 }  // namespace Microsoft::MixedReality::Sharing::StateSync

--- a/libs/StateSync-cpp/src/CommandId.cpp
+++ b/libs/StateSync-cpp/src/CommandId.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "src/pch.h"
+
+#include <Microsoft/MixedReality/Sharing/StateSync/CommandId.h>
+
+#include <Microsoft/MixedReality/Sharing/Common/RandomDevice.h>
+
+namespace Microsoft::MixedReality::Sharing::StateSync {
+
+CommandId CommandId::GenerateRandom() noexcept {
+  auto& rng = RandomDevice::thread_instance();
+  return {rng(), rng()};
+}
+
+}  // namespace Microsoft::MixedReality::Sharing::StateSync

--- a/libs/StateSync-cpp/src/pch.h
+++ b/libs/StateSync-cpp/src/pch.h
@@ -15,8 +15,10 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
RSMs should be able to generate message IDs even if the connection to the authority is down (and thus we can't, for example, obtain the base non-colliding ID from the authority).

The implementation is based on the public-domain [xoshiro256++](http://prng.di.unimi.it/)
See the license details in the [reference implementation](http://prng.di.unimi.it/xoshiro256plusplus.c).

The same infrastructure can be used later for random RAFT latencies etc.