### PR TITLE
Fix repository generation

### DIFF
--- a/tools/ci/commitGeneratedDocs.ps1
+++ b/tools/ci/commitGeneratedDocs.ps1
@@ -73,14 +73,9 @@ Write-Host "Destination folder: $DestFolder"
 # Note that we always clone into $StagingFolder, which is the repository root,
 # even if the destination folder is a sub-folder.
 Write-Host "Clone the generated docs branch"
-$cloneCommand = "git -c http.extraheader=""AUTHORIZATION: $Authorization"" clone https://github.com/Microsoft/MixedReality-Sharing.git --branch gh-pages ""$StagingFolder"""
+$cloneCommand = "git -c http.extraheader=""AUTHORIZATION: $Authorization"" clone https://github.com/Microsoft/MixedReality-Sharing.git --branch gh-pages ""$StagingFolder"" --no-checkout"
 # Pass a custom display name so that credentials are not printed out in case of error.
 Invoke-NoFailOnStdErr $cloneCommand "git clone ..."
-
-# Delete all the files in this folder, so that files deleted in the new version
-# of the documentation are effectively deleted in the commit.
-Write-Host "Delete currently committed version"
-Ensure-Empty $DestFolder
 
 # Copy the newly-generated version of the docs
 Write-Host "Copy new generated version"

--- a/tools/ci/commitGeneratedDocs.ps1
+++ b/tools/ci/commitGeneratedDocs.ps1
@@ -73,7 +73,7 @@ Write-Host "Destination folder: $DestFolder"
 # Note that we always clone into $StagingFolder, which is the repository root,
 # even if the destination folder is a sub-folder.
 Write-Host "Clone the generated docs branch"
-$cloneCommand = "git -c http.extraheader=""AUTHORIZATION: $Authorization"" clone https://github.com/Microsoft/MixedReality-Sharing.git --branch gh-pages ""$StagingFolder"" --no-checkout"
+$cloneCommand = "git -c http.extraheader=""AUTHORIZATION: $Authorization"" clone https://github.com/Microsoft/MixedReality-Sharing.git --branch gh-pages --no-checkout ""$StagingFolder"""
 # Pass a custom display name so that credentials are not printed out in case of error.
 Invoke-NoFailOnStdErr $cloneCommand -DisplayName "git clone ..."
 
@@ -91,6 +91,9 @@ try {
     Write-Host "Set docs commit author to '${env:GITHUB_NAME} <${env:GITHUB_EMAIL}>'"
     git config user.name ${env:GITHUB_NAME}
     git config user.email ${env:GITHUB_EMAIL}
+
+    # After "git clone --no-checkout" the index contains all files as deleted, clear it
+    git reset
 
     # Check for any change compared to previous version (if any)
     Write-Host "Check for changes"

--- a/tools/ci/commitGeneratedDocs.ps1
+++ b/tools/ci/commitGeneratedDocs.ps1
@@ -75,7 +75,7 @@ Write-Host "Destination folder: $DestFolder"
 Write-Host "Clone the generated docs branch"
 $cloneCommand = "git -c http.extraheader=""AUTHORIZATION: $Authorization"" clone https://github.com/Microsoft/MixedReality-Sharing.git --branch gh-pages ""$StagingFolder"" --no-checkout"
 # Pass a custom display name so that credentials are not printed out in case of error.
-Invoke-NoFailOnStdErr $cloneCommand "git clone ..."
+Invoke-NoFailOnStdErr $cloneCommand -DisplayName "git clone ..."
 
 # Copy the newly-generated version of the docs
 Write-Host "Copy new generated version"
@@ -102,7 +102,7 @@ try {
         # this directory and retain only generated docs changes, which is exactly what we want.
         Invoke-NoFailOnStdErr "git add --all"
         Invoke-NoFailOnStdErr "git commit -m ""Generated docs for commit $commitSha ($commitTitle)"""
-        Invoke-NoFailOnStdErr "git -c http.extraheader=""AUTHORIZATION: $Authorization"" push origin ""$DestBranch""" "git push..."
+        Invoke-NoFailOnStdErr "git -c http.extraheader=""AUTHORIZATION: $Authorization"" push origin ""$DestBranch""" -DisplayName "git push..."
         Write-Host "Docs changes committed"
     } else {
         Write-Host "Docs are up to date"

--- a/tools/ci/templates/steps-docs.yaml
+++ b/tools/ci/templates/steps-docs.yaml
@@ -25,7 +25,7 @@ steps:
     inputs:
       targetType: filePath
       filePath: tools/ci/commitGeneratedDocs.ps1
-      arguments: '-SourceBranch $(Build.SourceBranch)'
+      arguments: '-SourceBranch $(Build.SourceBranch) -StagingFolder $(Agent.TempDirectory)\docs_to_push'
       failOnStderr: false
     env:
       GITHUB_PAT: $(GitHub.PAT)

--- a/tools/ci/utils.ps1
+++ b/tools/ci/utils.ps1
@@ -34,6 +34,6 @@ function Invoke-NoFailOnStdErr($Command, $DisplayName = $Command) {
 
 # Ensure that the directory at the given path exists and is empty.
 function Ensure-Empty($DirectoryPath) {
-    mkdir -Force $DirectoryPath | out-null
+    mkdir -Force "$DirectoryPath" | out-null
     Remove-Item "$DirectoryPath\*" -Force -Recurse
 }


### PR DESCRIPTION
Emptying $DestFolder deleted the .git folder too when the pipeline was run on the master branch. This made the following git commands fail.